### PR TITLE
Rename commands and clean up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "vscode-extension-sidebar-html",
+  "name": "in-your-face",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-extension-sidebar-html",
+      "name": "in-your-face",
       "version": "1.0.0",
-      "license": "BSD-3-Clause",
+      "license": "MIT",
       "devDependencies": {
         "@types/glob": "^7.1.4",
         "@types/mocha": "^9.0.0",
@@ -141,7 +141,6 @@
       "engines": {
         "node": ">= 8"
       }
-
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
@@ -2007,7 +2006,8 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
-      "funding": [{
+      "funding": [
+        {
           "type": "github",
           "url": "https://github.com/sponsors/feross"
         },
@@ -2126,7 +2126,8 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
-      "funding": [{
+      "funding": [
+        {
           "type": "github",
           "url": "https://github.com/sponsors/feross"
         },

--- a/package.json
+++ b/package.json
@@ -35,44 +35,33 @@
     "publisherDisplayName": "Virej Dasani"
   },
   "activationEvents": [
-    "onCommand:vscodeSidebar.openview",
-    "onView:vscodeSidebar.openview"
+    "onCommand:in-your-face.openview.focus",
+    "onView:in-your-face.openview"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "viewsContainers": {
       "activitybar": [{
         "id": "custom-activitybar",
-        "title": "VSCode Extension",
+        "title": "In Your Face",
         "icon": "assets/logo_bito.svg"
       }]
     },
     "views": {
       "custom-activitybar": [{
         "type": "webview",
-        "id": "vscodeSidebar.openview",
+        "id": "in-your-face.openview",
         "name": "In Your Face",
         "contextualTitle": "In Your Face"
       }]
     },
     "commands": [{
-        "command": "vscodeSidebar.openview",
-        "title": "Sidebar View"
-      },
-      {
-        "command": "vscodeSidebar.menu.view",
-        "category": "vscode-extension-sidebar-html",
-        "title": "Sample WebView in VS Code Sidebar",
+        "command": "in-your-face.openview.focus",
+        "category": "In Your Face",
+        "title": "Open Sidebar",
         "icon": "$(clear-all)"
       }
-    ],
-    "menus": {
-      "view/title": [{
-        "command": "vscodeSidebar.menu.view",
-        "group": "navigation",
-        "when": "view == vscodeSidebar.openview"
-      }]
-    }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,7 +177,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 class CustomSidebarViewProvider implements vscode.WebviewViewProvider {
-  public static readonly viewType = "vscodeSidebar.openview";
+  public static readonly viewType = "in-your-face.openview";
 
   private _view?: vscode.WebviewView;
 


### PR DESCRIPTION
**✏ What was changed?**

Mostly metadata that describes the extension.

All commands used to say `vscodeSidebar.cmd`; now updated to `in-your-face.cmd`. Also, `vscodeSidebar.menu.view` is not associated with any action, so I deleted its related code.

`src/extension.ts` was also modified to reflect the command name changes in the package file. `package-lock.json` was updated with the command `npm i --package-lock-only`

**💻 How does this affect the extension?**

Before, if you hovered the extension icon in the sidebar, it would say "VSCode Extension." From the command palette, the action had a name like `vscode-extension-sidebar-html: Sample WebView in VS Code Sidebar`. These sorts of things are fixed in this pull request.

**💬 Any other comments?**

Feel free to edit my changes for possible mistakes. Thank you for taking the time to read my pull request! (Also, BTW, I love your YouTube channel).